### PR TITLE
Fix module imports

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,2 @@
+import "./package/Matter";
+export * from "./package/matter-hooks";

--- a/lib/package/matter-hooks/index.d.ts
+++ b/lib/package/matter-hooks/index.d.ts
@@ -6,15 +6,15 @@ import type {
 	AsyncResult,
 	AsyncSuccess,
 } from "./useAsync";
-import { useAsync } from "./useAsync";
-import { useChange } from "./useChange";
+import useAsync from "./useAsync";
+import useChange from "./useChange";
 import type { ContextActionOptions } from "./useContextAction";
-import { useContextAction } from "./useContextAction";
-import { useMap } from "./useMap";
-import { useMemo } from "./useMemo";
-import { useReducer } from "./useReducer";
+import useContextAction from "./useContextAction";
+import useMap from "./useMap";
+import useMemo from "./useMemo";
+import useReducer from "./useReducer";
 import type { StreamEvent, StreamInEvent, StreamOptions, StreamOutEvent } from "./useStream";
-import { useStream } from "./useStream";
+import useStream from "./useStream";
 
 export type {
 	AsyncComplete,

--- a/lib/package/matter-hooks/useAsync.d.ts
+++ b/lib/package/matter-hooks/useAsync.d.ts
@@ -21,7 +21,7 @@ export type AsyncIncomplete = {
 
 export type AsyncReady<T> = AsyncComplete<T> | AsyncIncomplete;
 
-export function useAsync<T>(
+export default function useAsync<T>(
 	callback: () => T,
 	dependencies: unknown[],
 	discriminator?: unknown,

--- a/lib/package/matter-hooks/useChange.d.ts
+++ b/lib/package/matter-hooks/useChange.d.ts
@@ -1,1 +1,1 @@
-export function useChange(dependencies: unknown[], discriminator?: unknown): boolean;
+export default function useChange(dependencies: unknown[], discriminator?: unknown): boolean;

--- a/lib/package/matter-hooks/useContextAction.d.ts
+++ b/lib/package/matter-hooks/useContextAction.d.ts
@@ -3,7 +3,7 @@ export type ContextActionOptions = {
 	inputTypes?: (Enum.KeyCode | Enum.UserInputType)[];
 };
 
-export function useContextAction(
+export default function useContextAction(
 	actionName: string,
 	callback: (
 		actionName: string,

--- a/lib/package/matter-hooks/useMap.d.ts
+++ b/lib/package/matter-hooks/useMap.d.ts
@@ -1,1 +1,1 @@
-export function useMap<T>(key: unknown, defaultValue: T): { value: T };
+export default function useMap<T>(key: unknown, defaultValue: T): { value: T };

--- a/lib/package/matter-hooks/useMemo.d.ts
+++ b/lib/package/matter-hooks/useMemo.d.ts
@@ -1,6 +1,10 @@
-export function useMemo<T>(callback: () => T, dependencies: unknown[], discriminator?: unknown): T;
+export default function useMemo<T>(
+	callback: () => T,
+	dependencies: unknown[],
+	discriminator?: unknown,
+): T;
 
-export function useMemo<T extends defined[]>(
+export default function useMemo<T extends defined[]>(
 	callback: () => LuaTuple<T>,
 	dependencies: unknown[],
 	discriminator?: unknown,

--- a/lib/package/matter-hooks/useReducer.d.ts
+++ b/lib/package/matter-hooks/useReducer.d.ts
@@ -1,4 +1,4 @@
-export function useReducer<S, A>(
+export default function useReducer<S, A>(
 	reducer: (state: S, action: A) => S,
 	initialState: S,
 	discriminator?: unknown,

--- a/lib/package/matter-hooks/useStream.d.ts
+++ b/lib/package/matter-hooks/useStream.d.ts
@@ -19,7 +19,7 @@ export type StreamOutEvent = {
 
 export type StreamEvent = StreamInEvent | StreamOutEvent;
 
-export function useStream(
+export default function useStream(
 	id: unknown,
 	options?: StreamOptions,
 ): () => LuaTuple<[number, StreamEvent]> | void;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 	"bugs": "https://github.com/LastTalon/matter-hooks-types/issues",
 	"author": "Lucas Gangstad <lucas@lasttalon.dev>",
 	"license": "MIT",
-	"main": "out/package/matter-hooks/init.lua",
-	"types": "out/package/matter-hooks/index.d.ts",
+	"main": "out/init.lua",
+	"types": "out/index.d.ts",
 	"files": [
 		"out",
 		"!**/*.tsbuildinfo"


### PR DESCRIPTION
## Proposed changes

The previous import method didn't pass along the TS runtime correctly. This adds a shim for the whole module that exports the rest of the module and also initializes dependencies with the runtime.

Additionally, this fixes default imports of individual hooks.
