### PR TITLE
Bump matter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"dependencies": {
-		"@rbxts/matter": "0.6.2-ts.6 - 0.8"
+	"peerDependencies": {
+		"@rbxts/matter": ">=0.6.2-ts.6 <0.9.0"
 	},
 	"devDependencies": {
-		"@rbxts/compiler-types": "^2.0.4-types.1",
+		"@rbxts/compiler-types": "^2.2.0-types.0",
 		"@rbxts/types": "^1.0.666",
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",


### PR DESCRIPTION
## Proposed changes

This maintains compatibility with matter as a peer dependency through v0.9.0 (non-inclusive). This is what matter-hooks is meant to be, but can't express in wally's manifest format.